### PR TITLE
Modernize dietaryindex fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 ## Overview
 ___
 
-**dietaryindex** is an R package that provides user-friendly, streamlined methods for standardizing the compilation of dietary intake data into index-based dietary patterns to enable the assessment of adherence to these patterns in epidemiologic and clinical studies. It has been peer-reviewed and published in the **[American Journal of Clinical Nutrition](https://ajcn.nutrition.org/article/S0002-9165(24)00672-5/abstract)**.
+**dietaryindex** is an R package that provides user-friendly, streamlined methods for standardizing the compilation of dietary intake data into index-based dietary patterns. It has been peer-reviewed and published in the **[American Journal of Clinical Nutrition](https://ajcn.nutrition.org/article/S0002-9165(24)00672-5/abstract)**.
+
+This repository is a modernization of the original work by **Jiada (James) Zhan** and colleagues available at [github.com/jamesjiadazhan/dietaryindex](https://github.com/jamesjiadazhan/dietaryindex). The University of Florida team is extending the project to provide a lightweight website and Python utilities for computing the Dietary Inflammatory Index (DII), MIND diet score, and Healthy Eating Index (HEI). Development of this fork leverages GitHub's **Codex** to assist with maintenance and automation. All original and new contributions remain under the MIT License.
 
 ## User-friendly tutorial page
 ___
@@ -19,6 +21,10 @@ If you are using the Dietaryindex package in your research, **please be sure to 
   - Zhe Xu. (2024) 'Improving the dietaryindex R Package: A Proposal to Include Additional Components for More Accurate DII Computation in NHANES', *The American Journal of Clinical Nutrition*. doi: 10.1016/j.ajcnut.2024.10.023.
 - **Biorxiv Preprint**:
   - Jiada James Zhan, Rebecca A Hodge, Anne Dunlop, et al. 'Dietaryindex: A User-Friendly and Versatile R Package for Standardizing Dietary Pattern Analysis in Epidemiological and Clinical Studies'. *bioRxiv*. Published online August 07, 2023:2023.08.07.548466. doi:10.1101/2023.08.07.548466
+
+If you make use of the additional Python modules or the web interface provided in this repository, please cite this fork as:
+
+Clark E, Zhan JJ. "Modernizing dietaryindex with Python utilities and a web-based interface". University of Florida, 2024. https://github.com/jamesjiadazhan/dietaryindex
 
 ## How dietaryindex works
 ___
@@ -112,16 +118,16 @@ install_github("jamesjiadazhan/dietaryindex")
 ```
 
 ### Python usage
-In addition to the original R package, a minimal Python reimplementation is
-included in this repository.  Install it in editable mode and import the
-``acs2020_v1`` function:
+In addition to the original R package, Python utilities are provided for quick
+calculations of several dietary indexes. Install the project in editable mode
+and import the helpers:
 
 ```bash
 pip install -e .
 ```
 
 ```python
-from dietaryindex_py import acs2020_v1
+from dietaryindex_py import acs2020_v1, dii_score, mind_score, hei_score
 ```
 
 Development containers with both R and Python are provided under the
@@ -166,7 +172,13 @@ For NHANES data:
 
 FPED, NUTRIENT, and DEMO files are available within the package and in the another GitHub repository and Google Drive collected by the package developer for your convenience
 - https://github.com/jamesjiadazhan/dietaryindex_manual
-- https://drive.google.com/drive/folders/1umjhuS22aHEW_bU5AjYa8vrae91gsb0D?usp=share_link 
+- https://drive.google.com/drive/folders/1umjhuS22aHEW_bU5AjYa8vrae91gsb0D?usp=share_link
+
+### Modernization & Website
+___
+This fork is maintained by researchers at the **University of Florida** (contact: edward.clark@ufl.edu). Our goal is to build an accessible web interface for calculating **DII**, **MIND**, and **HEI** scores directly in the browser. A preview is available at **index.html** in this repository and will be hosted via GitHub Pages.
+
+We are experimenting with GitHub's Codex to automate code maintenance. Feedback and contributions are welcome!
 
 ### Contributing & Notes
 ___

--- a/dietaryindex_py/__init__.py
+++ b/dietaryindex_py/__init__.py
@@ -1,5 +1,13 @@
 """Python utilities for computing dietary indexes."""
 
 from .acs2020 import acs2020_v1
+from .dii import dii_score
+from .mind import mind_score
+from .hei import hei_score
 
-__all__ = ["acs2020_v1"]
+__all__ = [
+    "acs2020_v1",
+    "dii_score",
+    "mind_score",
+    "hei_score",
+]

--- a/dietaryindex_py/acs2020.py
+++ b/dietaryindex_py/acs2020.py
@@ -2,23 +2,16 @@ import pandas as pd
 
 
 def _quintile_scores(series: pd.Series, ascending: bool, scores: list) -> pd.Series:
-    """Assign quintile-based scores to a pandas Series."""
-    quantiles = series.quantile([0.25, 0.5, 0.75]).tolist()
-    q1, q2, q3 = quantiles
-    if ascending:
-        return pd.cut(
-            series,
-            bins=[-float('inf'), q1, q2, q3, float('inf')],
-            labels=scores,
-            include_lowest=True,
-        ).astype(float)
-    else:
-        return pd.cut(
-            series,
-            bins=[-float('inf'), q3, q2, q1, float('inf')],
-            labels=scores,
-            include_lowest=True,
-        ).astype(float)
+    """Assign quintile-based scores using ranking."""
+    ranks = series.rank(method="average", pct=True)
+    if not ascending:
+        ranks = 1 - ranks
+    return pd.cut(
+        ranks,
+        bins=[0, 0.25, 0.5, 0.75, 1.0],
+        labels=scores,
+        include_lowest=True,
+    ).astype(float)
 
 
 def acs2020_v1(df: pd.DataFrame) -> pd.DataFrame:

--- a/dietaryindex_py/dii.py
+++ b/dietaryindex_py/dii.py
@@ -1,0 +1,77 @@
+import pandas as pd
+from math import erf, sqrt
+
+# Map variable -> (overall_inflammatory_score, global_mean, sd)
+_DII_DATA = {
+    "ALCOHOL_DII": (-0.278, 13.98, 3.72),
+    "VITB12_DII": (0.106, 5.15, 2.7),
+    "VITB6_DII": (-0.365, 1.47, 0.74),
+    "BCAROTENE_DII": (-0.584, 3718, 1720),
+    "CAFFEINE_DII": (-0.11, 8.05, 6.67),
+    "CARB_DII": (0.097, 272.2, 40),
+    "CHOLES_DII": (0.11, 279.4, 51.2),
+    "KCAL_DII": (0.18, 2056, 338),
+    "EUGENOL_DII": (-0.14, 0.01, 0.08),
+    "TOTALFAT_DII": (0.298, 71.4, 19.4),
+    "FIBER_DII": (-0.663, 18.8, 4.9),
+    "FOLICACID_DII": (-0.19, 273, 70.7),
+    "GARLIC_DII": (-0.412, 4.35, 2.9),
+    "GINGER_DII": (-0.453, 59, 63.2),
+    "IRON_DII": (0.032, 13.35, 3.71),
+    "MG_DII": (-0.484, 310.1, 139.4),
+    "MUFA_DII": (-0.009, 27, 6.1),
+    "NIACIN_DII": (-0.246, 25.9, 11.77),
+    "N3FAT_DII": (-0.436, 1.06, 1.06),
+    "N6FAT_DII": (-0.159, 10.8, 7.5),
+    "ONION_DII": (-0.301, 35.9, 18.4),
+    "PROTEIN_DII": (0.021, 79.4, 13.9),
+    "PUFA_DII": (-0.337, 13.88, 3.76),
+    "RIBOFLAVIN_DII": (-0.068, 1.7, 0.79),
+    "SAFFRON_DII": (-0.14, 0.37, 1.78),
+    "SATFAT_DII": (0.373, 28.6, 8),
+    "SE_DII": (-0.191, 67, 25.1),
+    "THIAMIN_DII": (-0.098, 1.7, 0.66),
+    "TRANSFAT_DII": (0.229, 3.75, 3.75),
+    "TURMERIC_DII": (-0.785, 533.6, 754.3),
+    "VITA_DII": (-0.401, 983.9, 518.6),
+    "VITC_DII": (-0.424, 118.2, 43.46),
+    "VITD_DII": (-0.446, 6.26, 2.21),
+    "VITE_DII": (-0.419, 8.73, 1.49),
+    "ZN_DII": (-0.313, 9.84, 2.19),
+    "TEA_DII": (-0.536, 1.69, 1.53),
+    "FLA3OL_DII": (-0.415, 95.8, 85.9),
+    "FLAVONES_DII": (-0.616, 1.55, 0.07),
+    "FLAVONOLS_DII": (-0.467, 17.7, 6.79),
+    "FLAVONONES_DII": (-0.25, 11.7, 3.82),
+    "ANTHOC_DII": (-0.131, 18.05, 21.14),
+    "ISOFLAVONES_DII": (-0.593, 1.2, 0.2),
+    "PEPPER_DII": (-0.131, 10, 7.07),
+    "THYME_DII": (-0.102, 0.33, 0.99),
+    "ROSEMARY_DII": (-0.013, 1, 15),
+}
+
+def _pnorm(z: pd.Series) -> pd.Series:
+    """Normal CDF using the error function."""
+    return (1.0 + (z / sqrt(2)).apply(erf)) / 2.0
+
+
+def dii_score(df: pd.DataFrame) -> pd.Series:
+    """Compute a simplified Dietary Inflammatory Index.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Data frame containing columns named as in `_DII_DATA`.
+
+    Returns
+    -------
+    pandas.Series
+        Total DII score for each row.
+    """
+    score = pd.Series(0.0, index=df.index)
+    for var, (coef, mean, sd) in _DII_DATA.items():
+        if var in df.columns:
+            z = (df[var] - mean) / sd
+            perc = _pnorm(z) * 2 - 1
+            score += perc * coef
+    return score

--- a/dietaryindex_py/hei.py
+++ b/dietaryindex_py/hei.py
@@ -1,0 +1,28 @@
+import pandas as pd
+
+_COMPONENTS = [
+    "TOTAL_FRT", "WHOLE_FRT", "TOTAL_VEG", "GREENS_BEANS", "WHOLE_GRAIN",
+    "DAIRY", "TOTAL_PROTEIN", "SEA_PLANT_PROTEIN", "FATTY_ACID",
+    "REFINED_GRAIN", "SODIUM", "ADDED_SUGARS", "SAT_FAT",
+]
+
+_MAX_SCORES = {
+    "TOTAL_FRT": 5, "WHOLE_FRT": 5, "TOTAL_VEG": 5, "GREENS_BEANS": 5,
+    "WHOLE_GRAIN": 10, "DAIRY": 10, "TOTAL_PROTEIN": 5,
+    "SEA_PLANT_PROTEIN": 5, "FATTY_ACID": 10, "REFINED_GRAIN": 10,
+    "SODIUM": 10, "ADDED_SUGARS": 10, "SAT_FAT": 10,
+}
+
+def hei_score(df: pd.DataFrame) -> pd.Series:
+    """Compute a very simplified HEI-style score.
+
+    This function expects columns named as in `_COMPONENTS`. The component
+    scores are assumed to be pre-scaled from 0 to the component maximum.
+    The total score is the sum of available component columns and may
+    range up to 100.
+    """
+    score = pd.Series(0.0, index=df.index)
+    for comp in _COMPONENTS:
+        if comp in df.columns:
+            score += df[comp].clip(lower=0, upper=_MAX_SCORES[comp])
+    return score

--- a/dietaryindex_py/mind.py
+++ b/dietaryindex_py/mind.py
@@ -1,0 +1,25 @@
+import pandas as pd
+
+_HEALTHY = [
+    "GREEN_LEAFY", "OTHER_VEG", "NUTS", "BERRIES", "BEANS",
+    "WHOLE_GRAINS", "FISH", "POULTRY", "OLIVE_OIL", "WINE",
+]
+_UNHEALTHY = [
+    "RED_MEAT", "BUTTER", "CHEESE", "PASTRIES", "FRIED_FOOD",
+]
+
+def mind_score(df: pd.DataFrame) -> pd.Series:
+    """Compute a simplified MIND diet score.
+
+    Each healthy food group counts as 1 point if the intake column is >0,
+    and each unhealthy food group counts as 1 point if the intake is 0.
+    The total score ranges from 0 to 15.
+    """
+    score = pd.Series(0, index=df.index, dtype=float)
+    for col in _HEALTHY:
+        if col in df.columns:
+            score += (df[col] > 0).astype(float)
+    for col in _UNHEALTHY:
+        if col in df.columns:
+            score += (df[col] == 0).astype(float)
+    return score

--- a/index.html
+++ b/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>dietaryindex</title>
+  <style>
+    body {font-family: Arial, sans-serif; margin: 2em; max-width: 800px;}
+    header {border-bottom: 1px solid #ccc; margin-bottom: 1em;}
+    footer {margin-top: 2em; font-size: 0.9em; color: #555;}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>dietaryindex</h1>
+    <p>An open-source toolkit for computing dietary pattern indexes.</p>
+  </header>
+
+  <p>This website accompanies the <code>dietaryindex</code> repository. The project was
+  originally created by <a href="https://github.com/jamesjiadazhan">Jiada (James) Zhan</a>
+  and colleagues. The University of Florida is extending the software with a
+  modernized interface and additional Python utilities. The goal is to provide
+  simple online calculators for the Dietary Inflammatory Index (DII), MIND diet
+  score and Healthy Eating Index (HEI).</p>
+
+  <h2>Python Examples</h2>
+  <pre><code>pip install -e .
+from dietaryindex_py import dii_score, mind_score, hei_score
+</code></pre>
+
+  <h2>License</h2>
+  <p>All code is released under the MIT License. See <a href="other/LICENSE.txt">LICENSE.txt</a>.</p>
+
+  <footer>
+    <p>Maintained by the University of Florida. Built with the help of GitHub Codex.</p>
+  </footer>
+</body>
+</html>

--- a/tests/test_simple_scores.py
+++ b/tests/test_simple_scores.py
@@ -1,0 +1,30 @@
+import pandas as pd
+from dietaryindex_py import dii_score, mind_score, hei_score
+
+
+def test_dii_score_basic():
+    df = pd.DataFrame({
+        "ALCOHOL_DII": [10, 20],
+        "VITB12_DII": [5, 4],
+    })
+    score = dii_score(df)
+    assert len(score) == 2
+    assert score.notna().all()
+
+
+def test_mind_score_basic():
+    df = pd.DataFrame({
+        "GREEN_LEAFY": [1, 0],
+        "RED_MEAT": [0, 1],
+    })
+    result = mind_score(df)
+    assert result.iloc[0] > result.iloc[1]
+
+
+def test_hei_score_basic():
+    df = pd.DataFrame({
+        "TOTAL_FRT": [5, 1],
+        "WHOLE_FRT": [5, 1],
+    })
+    result = hei_score(df)
+    assert result.iloc[0] >= result.iloc[1]


### PR DESCRIPTION
## Summary
- credit original authors in README and mention UF modernization
- add website `index.html`
- provide Python utilities for DII, MIND, and HEI scores
- update module exports and tests
- fix quintile scoring for ACS2020 function

## Testing
- `pip install pandas`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ed7565d6483338a1326e82a02b632